### PR TITLE
changed assertion for results

### DIFF
--- a/ConstructionLine.CodingChallenge.Tests/SearchEnginePerformanceTests.cs
+++ b/ConstructionLine.CodingChallenge.Tests/SearchEnginePerformanceTests.cs
@@ -39,7 +39,7 @@ namespace ConstructionLine.CodingChallenge.Tests
             sw.Stop();
             Console.WriteLine($"Test fixture finished in {sw.ElapsedMilliseconds} milliseconds");
 
-            AssertResults(_shirts, options, results.Shirts);
+            AssertResults(results.Shirts, options);
             AssertSizeCounts(_shirts, options, results.SizeCounts);
             AssertColorCounts(_shirts, options, results.ColorCounts);
             Assert.That(sw.ElapsedMilliseconds, Is.LessThan(100));

--- a/ConstructionLine.CodingChallenge.Tests/SearchEngineTests.cs
+++ b/ConstructionLine.CodingChallenge.Tests/SearchEngineTests.cs
@@ -37,7 +37,7 @@ namespace ConstructionLine.CodingChallenge.Tests
 
             var results = _searchEngine.Search(searchOptions);
 
-            AssertResults(_shirts, searchOptions, results.Shirts);
+            AssertResults(results.Shirts, searchOptions);
             AssertSizeCounts(_shirts, searchOptions, results.SizeCounts);
             AssertColorCounts(_shirts, searchOptions, results.ColorCounts);
         }
@@ -51,8 +51,8 @@ namespace ConstructionLine.CodingChallenge.Tests
             };
 
             var results = _searchEngine.Search(searchOptions);
-
-            AssertResults(_shirts, searchOptions, results.Shirts);
+            
+            AssertResults(results.Shirts, searchOptions);
             AssertSizeCounts(_shirts, searchOptions, results.SizeCounts);
             AssertColorCounts(_shirts, searchOptions, results.ColorCounts);
         }
@@ -66,8 +66,8 @@ namespace ConstructionLine.CodingChallenge.Tests
             };
 
             var results = _searchEngine.Search(searchOptions);
-
-            AssertResults(_shirts, searchOptions, results.Shirts);
+            
+            AssertResults(results.Shirts, searchOptions);
             AssertSizeCounts(_shirts, searchOptions, results.SizeCounts);
             AssertColorCounts(_shirts, searchOptions, results.ColorCounts);
         }
@@ -83,7 +83,7 @@ namespace ConstructionLine.CodingChallenge.Tests
 
             var results = _searchEngine.Search(searchOptions);
 
-            AssertResults(_shirts, searchOptions, results.Shirts);
+            AssertResults(results.Shirts, searchOptions);
             AssertSizeCounts(_shirts, searchOptions, results.SizeCounts);
             AssertColorCounts(_shirts, searchOptions, results.ColorCounts);
         }
@@ -99,7 +99,7 @@ namespace ConstructionLine.CodingChallenge.Tests
 
             var results = _searchEngine.Search(searchOptions);
 
-            AssertResults(_shirts, searchOptions, results.Shirts);
+            AssertResults(results.Shirts, searchOptions);
             AssertSizeCounts(_shirts, searchOptions, results.SizeCounts);
             AssertColorCounts(_shirts, searchOptions, results.ColorCounts);
         }
@@ -114,7 +114,7 @@ namespace ConstructionLine.CodingChallenge.Tests
             };
             var results = _searchEngine.Search(searchOptions);
 
-            AssertResults(_shirts, searchOptions, results.Shirts);
+            AssertResults(results.Shirts, searchOptions);
             AssertSizeCounts(_shirts, searchOptions, results.SizeCounts);
             AssertColorCounts(_shirts, searchOptions, results.ColorCounts);
         }
@@ -130,7 +130,7 @@ namespace ConstructionLine.CodingChallenge.Tests
 
             var results = _searchEngine.Search(searchOptions);
 
-            AssertResults(_shirts, searchOptions, results.Shirts);
+            AssertResults(results.Shirts, searchOptions);
             AssertSizeCounts(_shirts, searchOptions, results.SizeCounts);
             AssertColorCounts(_shirts, searchOptions, results.ColorCounts);
         }

--- a/ConstructionLine.CodingChallenge.Tests/SearchEngineTestsBase.cs
+++ b/ConstructionLine.CodingChallenge.Tests/SearchEngineTestsBase.cs
@@ -6,17 +6,24 @@ namespace ConstructionLine.CodingChallenge.Tests
 {
     public class SearchEngineTestsBase
     {
-        protected static void AssertResults(List<Shirt> shirts, SearchOptions options, List<Shirt> resultShirts)
+        protected static void AssertResults(List<Shirt> shirts, SearchOptions options)
         {
-            Assert.That(resultShirts, Is.Not.Null);
+            Assert.That(shirts, Is.Not.Null);
 
-            foreach (var shirt in shirts.Where(shirt => 
-                    (!options.Colors.Any() || options.Colors.Contains(shirt.Color)) 
-                &&  (!options.Sizes.Any() || options.Sizes.Contains(shirt.Size))))
+            if (!options.Sizes.Any()) 
+                options.Sizes = Size.All;
+
+            if (!options.Colors.Any())
+                options.Colors = Color.All;
+
+            var sizeIds = options.Sizes.Select(s => s.Id).ToList();
+            var colorIds = options.Colors.Select(c => c.Id).ToList();
+            
+            foreach (var shirt in shirts)
             {
-                if (!resultShirts.Contains(shirt))
+                if (!sizeIds.Contains(shirt.Size.Id) || !colorIds.Contains(shirt.Color.Id))
                 {
-                    Assert.Fail($"'{shirt.Name}' with Size '{shirt.Size.Name}' and Color '{shirt.Color.Name}' not found in results, " +
+                    Assert.Fail($"'{shirt.Name}' with Size '{shirt.Size.Name}' and Color '{shirt.Color.Name}' found in results, " +
                                 $"when selected sizes where '{string.Join(",", options.Sizes.Select(s => s.Name))}' " +
                                 $"and colors '{string.Join(",", options.Colors.Select(c => c.Name))}'");
                 }


### PR DESCRIPTION
Reverted back to existing signature to use shirt results and search option to perform verification.

The assertion has changed to verify that each shirt in the result is in the size or color selected.